### PR TITLE
Унификация логики работы с диалоговыми окнами

### DIFF
--- a/ReportEngine.App/Services/DialogService.cs
+++ b/ReportEngine.App/Services/DialogService.cs
@@ -26,7 +26,8 @@ public class DialogService : IDialogService
         {
             T selectedItem = null;
             var factory = _serviceProvider.GetRequiredService<GenericEquipWindowFactory>();
-            var window = factory.CreateWindow<T>();
+            var window = factory.CreateWindow<T>(true);
+
 
             if (window.DataContext is GenericEquipViewModel<T> viewModel)
                 viewModel.SelectionHandler = item =>
@@ -34,6 +35,8 @@ public class DialogService : IDialogService
                     selectedItem = item;
                     window.Close();
                 };
+
+
             window.ShowDialog();
             return selectedItem;
         }
@@ -74,7 +77,10 @@ public class DialogService : IDialogService
 
             viewModel.SelectionHandler = item => { selected = item; };
 
-            var window = new AllSortamentsView(viewModel);
+            var window = new AllSortamentsView(viewModel, true);
+
+            window.EquipDataGrid.IsReadOnly = true;
+
             window.ShowDialog();
 
             return selected;
@@ -96,7 +102,9 @@ public class DialogService : IDialogService
 
             viewModel.SelectedItem = item => { selected = item; };
 
-            var window = new CompanyView(viewModel);
+            var window = new CompanyView(viewModel, true);
+            window.CompaniesDataGrid.IsReadOnly = true;
+
             window.ShowDialog();
             return selected;
         }
@@ -117,7 +125,9 @@ public class DialogService : IDialogService
 
             viewModel.SelectedItem = item => { selected = item; };
 
-            var window = new SubjectsView(viewModel);
+            var window = new SubjectsView(viewModel, true);
+            window.SubjectsDataGrid.IsReadOnly = true;
+
             window.ShowDialog();
             return selected;
         }
@@ -139,6 +149,7 @@ public class DialogService : IDialogService
 
             viewModel.SelectedItem = item => { selected = item; };
 
+            window.FrameDataGrid.IsReadOnly = true;
             window.ShowDialog();
 
             return selected;

--- a/ReportEngine.App/Services/GenericEquipWindowFactory.cs
+++ b/ReportEngine.App/Services/GenericEquipWindowFactory.cs
@@ -22,14 +22,14 @@ public class GenericEquipWindowFactory
         _serviceProvider = serviceProvider;
     }
 
-    public Window CreateWindow<T>() where T : class, IBaseEquip, new()
+    public Window CreateWindow<T>(bool isDialog) where T : class, IBaseEquip, new()
     {
         // Получаем репозиторий из DI
         var repository = _serviceProvider.GetRequiredService<IGenericBaseRepository<T, T>>();
         // Создаем ViewModel
         var viewModel = new GenericEquipViewModel<T>(repository);
         // Создаем окно
-        var window = new GenericEquipView();
+        var window = new GenericEquipView(isDialog);
         // Устанавливаем DataContext окна на созданную ViewModel
         // Это позволяет окну использовать ViewModel для привязки данных
         window.DataContext = viewModel;
@@ -37,6 +37,11 @@ public class GenericEquipWindowFactory
         GenerateDataGridColumns<T>(window);
         // Выполняем команду для отображения всего оборудования
         viewModel.OnShowAllEquipCommandExecuted(null);
+
+        if (isDialog)
+        {
+            window.GenericEquipDataGrid.IsReadOnly = true;
+        }
         // Возвращаем созданное и настроенное окно
         return window;
     }

--- a/ReportEngine.App/Services/NavigationService.cs
+++ b/ReportEngine.App/Services/NavigationService.cs
@@ -35,7 +35,7 @@ public class NavigationService
         where T : class, IBaseEquip, new()
     {
         var factory = _serviceProvider.GetRequiredService<GenericEquipWindowFactory>(); // Получаем фабрику окон
-        _currentWindow = factory.CreateWindow<T>(); // Создаем окно с помощью фабрики
+        _currentWindow = factory.CreateWindow<T>(false); // Создаем окно с помощью фабрики
         _currentWindow.Show(); // Отображаем окно
     }
 

--- a/ReportEngine.App/ViewModels/ProjectViewModel.cs
+++ b/ReportEngine.App/ViewModels/ProjectViewModel.cs
@@ -17,7 +17,6 @@ using ReportEngine.Export.ExcelWork.Services.Interfaces;
 using ReportEngine.Shared.Config.IniHeleprs;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Runtime.Intrinsics.Arm;
 
 namespace ReportEngine.App.ViewModels;
 

--- a/ReportEngine.App/Views/Windows/AllSortamentsView.xaml.cs
+++ b/ReportEngine.App/Views/Windows/AllSortamentsView.xaml.cs
@@ -9,11 +9,13 @@ public partial class AllSortamentsView : Window
 {
     private readonly AllSortamentsViewModel _viewModel;
 
-    public AllSortamentsView(AllSortamentsViewModel viewModel)
+    private readonly bool _isDialog;
+    public AllSortamentsView(AllSortamentsViewModel viewModel, bool isDialog = false)
     {
         InitializeComponent();
         DataContext = viewModel;
         _viewModel = viewModel;
+        _isDialog = isDialog;
     }
 
     private async void SubTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -43,7 +45,7 @@ public partial class AllSortamentsView : Window
 
     private void SelectEquip_DoubleClick(object sender, MouseButtonEventArgs e)
     {
-        if (_viewModel.SelectedEquip != null)
+        if (_viewModel.SelectedEquip != null && _isDialog)
         {
             _viewModel.SelectionHandler?.Invoke(_viewModel.SelectedEquip);
             Close();

--- a/ReportEngine.App/Views/Windows/CompanyView.xaml.cs
+++ b/ReportEngine.App/Views/Windows/CompanyView.xaml.cs
@@ -15,10 +15,13 @@ public partial class CompanyView : Window
 {
     private ICollectionView _companiesView;
 
-    public CompanyView(CompanyViewModel viewModel)
+    private readonly bool _isDialog;
+
+    public CompanyView(CompanyViewModel viewModel, bool IsDialog = false)
     {
         InitializeComponent();
         DataContext = viewModel;
+        _isDialog = IsDialog;
 
         Loaded += async (_, __) => await InitializeDataAsync(viewModel);
     }
@@ -34,7 +37,7 @@ public partial class CompanyView : Window
 
     private void CompaniesDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        if (DataContext is CompanyViewModel vm && vm.CurrentCompany.SelectedCompany != null)
+        if (DataContext is CompanyViewModel vm && vm.CurrentCompany.SelectedCompany != null && _isDialog)
         {
             vm.SelectedItem?.Invoke(vm.CurrentCompany.SelectedCompany.Name);
             DialogResult = true;

--- a/ReportEngine.App/Views/Windows/FrameDialogView.xaml
+++ b/ReportEngine.App/Views/Windows/FrameDialogView.xaml
@@ -1,19 +1,20 @@
-﻿<Window x:Class="ReportEngine.App.Views.Windows.FrameDialogView"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        Title="Выбор рамы"
-        Width="800"
-        Height="700"
-        Background="{DynamicResource PrimaryColor}"
-        FontFamily="Bahnschrift"
-        FontSize="14"
-        Foreground="{DynamicResource PrimaryForeground}"
-        ResizeMode="NoResize"
-        WindowStartupLocation="CenterScreen"
-        WindowStyle="None"
-        mc:Ignorable="d">
+﻿<Window
+    x:Class="ReportEngine.App.Views.Windows.FrameDialogView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="Выбор рамы"
+    Width="800"
+    Height="700"
+    Background="{DynamicResource PrimaryColor}"
+    FontFamily="Bahnschrift"
+    FontSize="14"
+    Foreground="{DynamicResource PrimaryForeground}"
+    ResizeMode="NoResize"
+    WindowStartupLocation="CenterScreen"
+    WindowStyle="None"
+    mc:Ignorable="d">
 
     <WindowChrome.WindowChrome>
         <WindowChrome
@@ -75,13 +76,14 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <DataGrid
+                    x:Name="FrameDataGrid"
                     Grid.Column="0"
                     Margin="5"
                     AutoGenerateColumns="False"
                     CanUserAddRows="False"
                     ItemsSource="{Binding FormedFrameModel.AllFrames}"
-                    SelectedItem="{Binding FormedFrameModel.SelectedFrame}"
-                    MouseDoubleClick="FormedFrameGrid_MouseDoubleClick">
+                    MouseDoubleClick="FormedFrameGrid_MouseDoubleClick"
+                    SelectedItem="{Binding FormedFrameModel.SelectedFrame}">
                     <DataGrid.Columns>
                         <DataGridTextColumn Binding="{Binding Name}" Header="Наименование" />
                         <DataGridTextColumn Binding="{Binding FrameType}" Header="Тип" />

--- a/ReportEngine.App/Views/Windows/GenericEquipView.xaml.cs
+++ b/ReportEngine.App/Views/Windows/GenericEquipView.xaml.cs
@@ -10,15 +10,23 @@ namespace ReportEngine.App.Views.Windows;
 /// </summary>
 public partial class GenericEquipView : Window
 {
-    public GenericEquipView()
+    private readonly bool _isDialog;
+
+    public GenericEquipView(bool IsDialog = false)
     {
         InitializeComponent();
+        _isDialog = IsDialog;
     }
+
 
     private void SelectEquip_DoubleClick(object sender, MouseButtonEventArgs e)
     {
+        if (!_isDialog)
+            return;
+
         ExceptionHelper.SafeExecute(() =>
         {
+
             var type = DataContext.GetType();
 
             if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(GenericEquipViewModel<>))

--- a/ReportEngine.App/Views/Windows/SubjectsView.xaml.cs
+++ b/ReportEngine.App/Views/Windows/SubjectsView.xaml.cs
@@ -15,12 +15,16 @@ public partial class SubjectsView : Window
 {
     private ICollectionView _subjectsView;
 
-    public SubjectsView(SubjectViewModel viewModel)
+    private readonly bool _isDialog;
+    public SubjectsView(SubjectViewModel viewModel, bool isDialog = false)
     {
         InitializeComponent();
         DataContext = viewModel;
 
+        _isDialog = isDialog;
+
         Loaded += async (_, __) => await InitializeDataAsync(viewModel);
+        _isDialog = isDialog;
     }
 
     private async Task InitializeDataAsync(SubjectViewModel viewModel)
@@ -54,7 +58,7 @@ public partial class SubjectsView : Window
 
     private void SubjectsDataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        if (DataContext is SubjectViewModel vm && vm.CurrentSubject.SelectedSubject != null)
+        if (DataContext is SubjectViewModel vm && vm.CurrentSubject.SelectedSubject != null && _isDialog)
         {
             vm.SelectedItem?.Invoke(vm.CurrentSubject.SelectedSubject.ObjectName);
             DialogResult = true;


### PR DESCRIPTION
Добавлен параметр `isDialog` в конструкторах окон и фабрике `GenericEquipWindowFactory`, позволяющий определять, является ли окно диалоговым. Для диалоговых окон добавлены настройки, такие как установка свойства `IsReadOnly` для DataGrid и обработка выбора элементов только в диалоговом режиме.

Изменены методы создания окон в `DialogService` и
`NavigationService` для передачи параметра `isDialog`. Обновлены XAML-файлы для соответствия новым требованиям. Внесены мелкие изменения в форматирование для улучшения читаемости.